### PR TITLE
#697:  Fix runtime S3 issue in AWS WPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>netcdf-iterator</artifactId>
   <name>netcdf-iterator</name>
   <packaging>jar</packaging>
-  <version>1.0.1</version>
+  <version>1.0.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>netcdf-iterator</artifactId>
   <name>netcdf-iterator</name>
   <packaging>jar</packaging>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.1</version>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>edu.ucar</groupId>
       <artifactId>netcdfAll</artifactId>
-      <version>4.6.4</version>
+      <version>4.6.10</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Version 4.6.4 causing runtime S3 issue when netcdf-iterator library used in AWS WPS aggregation worker.