### PR TITLE
Use explicit netcdf dependencies instead of including 'shaded'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,12 @@
   <dependencies>
     <dependency>
       <groupId>edu.ucar</groupId>
-      <artifactId>netcdfAll</artifactId>
+      <artifactId>cdm</artifactId>
+      <version>4.6.10</version>
+    </dependency>
+    <dependency>
+      <groupId>edu.ucar</groupId>
+      <artifactId>opendap</artifactId>
       <version>4.6.10</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
netcdfAll jar as it includes old versions of the aws sdk's causing havoc in projects which use this